### PR TITLE
Use real error-rate data

### DIFF
--- a/src/components/ChartErrorRate.tsx
+++ b/src/components/ChartErrorRate.tsx
@@ -1,31 +1,24 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactECharts from 'echarts-for-react';
 import * as echarts from 'echarts/core';
 
+// ChartDataType is a type for the data that will be used in the chart. It will
+// be parsed from the data fetched from the API.
+type ChartDataType = {
+  errors: [string, number][];
+};
+
 const ChartErrorRate: React.FC = () => {
-  function generateApdexData() {
-    const data = [];
-    const now = new Date();
-    const threeDaysAgoTimestamp = new Date().setDate(now.getDate() - 3);
-    const threeDaysAgo = new Date(threeDaysAgoTimestamp);
+  const [chartData, setChartData] = useState<ChartDataType>({ errors: [] });
 
-    let i = 0;
-    for (let time = threeDaysAgo; time <= now; time = new Date(time.getTime() + 3600000)) {
-      let errorRate = 0.01;
-      errorRate += Math.random() * (0.02 - 0.008) + 0.008;
-
-      if (i > 30) {
-        errorRate += Math.random() * (0.2 - 0.1) + 0.1;
-      }
-
-      data.push([time, errorRate]);
-      i++;
-    }
-
-    return data;
-  }
-
-  const data = generateApdexData();
+  useEffect(() => {
+    fetch('http://localhost:3001/metrics/query')
+      .then(response => response.json())
+      .then((data: ChartDataType) => {
+        setChartData(data);
+      })
+      .catch(error => console.error("Failed to fetch data", error));
+  }, []);
 
   const option = {
     color: ['#c734f6'],
@@ -70,7 +63,7 @@ const ChartErrorRate: React.FC = () => {
       {
         type: 'line',
         name: 'Error Rate %',
-        data: data,
+        data: chartData.errors,
         smooth: true,
       }
     ],


### PR DESCRIPTION
* Objective

This commit objective is about using accurate error rate data on the error rate screen.

* Why

We were using actual data for the rest of the charts in the dashboard, but for the error rate, the error rate currently has some issues as the source that we've selected in the backend doesn't fail, so we have made a few tricks on the backend to simulate some error rate.

* How

This commit starts using the error rate received from the backend.