### PR TITLE
Use GET Transactions for the Transactions Table

### DIFF
--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
   Paper,
@@ -8,26 +8,17 @@ import {
   styled
 } from '@mui/material';
 
+interface ApiResponse {
+  transactions: Array<{
+    program_address: string;
+    percentage: number;
+  }>;
+}
+
 interface TransactionData {
   name: string;
   percentage: number;
 }
-
-const createData = (name: string, percentage: number): TransactionData => {
-  return { name, percentage };
-};
-const rows = [
-  createData('Index/getProgramAccount', 14.74 ),
-  createData('Phone/MobileData/ndTransaction', 14.78 ),
-  createData('Phone/Bluetooth/sendTransaction', 11.19 ),
-  createData('Phone/Register/sendTranstion', 10.43 ),
-  createData('Phone/Settings/sendTransaion', 8.12 ),
-  createData('Phone/Notications/sendTransaction', 7.65 ),
-  createData('Phone/Hotspot/sendTransaction', 6.34 ),
-  createData('Phone/Sound/sendTransaction', 6.21 ),
-  createData('Phone/General/sendTransaction', 3.19 ),
-  createData('Phone/Control/sendTransaction', 1.77 ),
-];
 
 const ColorLinearProgress = styled(LinearProgress)(({ value }: { value: number }) => ({
   '& .MuiLinearProgress-bar': {
@@ -36,12 +27,34 @@ const ColorLinearProgress = styled(LinearProgress)(({ value }: { value: number }
 }));
 
 const TransactionsTable = () => {
+  const [rows, setRows] = useState<TransactionData[]>([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/transactions/query')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then((data: ApiResponse) => {
+        const transactionsData = data.transactions.map(transaction => ({
+          name: transaction.program_address,
+          percentage: parseFloat(transaction.percentage.toFixed(2)),
+        }));
+        setRows(transactionsData);
+      })
+      .catch(error => {
+        console.error('There was a problem with your fetch operation:', error);
+      });
+  }, []);
+
   return (
     <TableContainer component={Paper}>
       <Table aria-label="simple table">
         <TableHead>
           <TableRow>
-            <TableCell>Transaction Type</TableCell>
+            <TableCell>Program</TableCell>
             <TableCell align="right">Percentage</TableCell>
           </TableRow>
         </TableHead>

--- a/src/pages/Transactions/Transactions.tsx
+++ b/src/pages/Transactions/Transactions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   Card,
@@ -19,19 +19,6 @@ import ChartThroughput from '../../components/ChartThroughput';
 import TransactionsTable from '../../components/TransactionsTable';
 
 const Transactions = () => {
-  const transactionData = [
-    { name: 'Index/getProgramAccount', percentage: 26.68 },
-    { name: 'Phone/Register/sendTransaction', percentage: 21.19 },
-    { name: 'Phone/Settings/sendTransaction', percentage: 21.19 },
-    { name: 'Phone/MobileData/sendTransaction', percentage: 21.19 },
-    { name: 'Phone/Notifications/sendTransaction', percentage: 21.19 },
-    { name: 'Phone/Bluetooth/sendTransaction', percentage: 21.19 },
-    { name: 'Phone/Hotspot/sendTransaction', percentage: 21.19 },
-    { name: 'Phone/Sound/sendTransaction', percentage: 21.19 },
-    { name: 'Phone/General/sendTransaction', percentage: 21.19 },
-    { name: 'Phone/Control/sendTransaction', percentage: 21.19 },
-  ];
-
   const transactionsChartData = {
     names: [
       'Index/getProgramAccount',


### PR DESCRIPTION
* Objective

This commit objective is about implementing the encinitas-collector GET Transactions endpoint to fetch real transactions information, instead of using generated mocks

* Why

The transactions table should use real data instead of mocked one now that we have a proper encinitas-collector running.

* How

This commit changes the encinitas-ui to perform the GET Transactions HTTP call and return the list of transactions and their load percentage.